### PR TITLE
Support Additional Claims in Service Credentials

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
-  gem.add_dependency "signet", "~> 0.7"
+  gem.add_dependency "signet", "0.11.0.liveramp-001"
 end

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.8.1".freeze
+    VERSION = "0.8.1.liveramp-001".freeze
   end
 end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -125,7 +125,8 @@ describe Google::Auth::ServiceAccountCredentials do
     @key = OpenSSL::PKey::RSA.new 2048
     @client = ServiceAccountCredentials.make_creds(
       json_key_io: StringIO.new(cred_json_text),
-      scope:       "https://www.googleapis.com/auth/userinfo.profile"
+      scope:       "https://www.googleapis.com/auth/userinfo.profile",
+      additional_claims: 'foobar'
     )
   end
 
@@ -366,7 +367,10 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
 
   before :example do
     @key = OpenSSL::PKey::RSA.new 2048
-    @client = clz.make_creds json_key_io: StringIO.new(cred_json_text)
+    @client = clz.make_creds(
+      json_key_io: StringIO.new(cred_json_text),
+      additional_claims: { target_audience: 'foobar' }
+    )
   end
 
   def cred_json_text


### PR DESCRIPTION
To support authenticating requests to applications behind IAP, the
access token needs to encode an additional claim for the
"target_audience" representing the client ID of the IAP instance. This
also updates the version of Signet used for the OAuth client to a
version that supports signing JWTs with addiitional claims.