### PR TITLE
Expose signing key / bump Signet dependency

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
-  gem.add_dependency "signet", "= 0.11.0.liveramp.pre.001"
+  gem.add_dependency "signet", "= 0.11.0.liveramp.pre.002"
 end

--- a/lib/googleauth/json_key_reader.rb
+++ b/lib/googleauth/json_key_reader.rb
@@ -34,12 +34,14 @@ module Google
     # JsonKeyReader contains the behaviour used to read private key and
     # client email fields from the service account
     module JsonKeyReader
-      def read_json_key json_key_io
+      def read_json_key(json_key_io, include_key_id = false)
         json_key = MultiJson.load json_key_io.read
         raise "missing client_email" unless json_key.key? "client_email"
         raise "missing private_key" unless json_key.key? "private_key"
         project_id = json_key["project_id"]
-        [json_key["private_key"], json_key["client_email"], project_id]
+        [json_key["private_key"], json_key["client_email"], project_id].tap do |arr|
+          arr << json_key["private_key_id"] if include_key_id
+        end
       end
     end
   end

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.8.1.liveramp-001".freeze
+    VERSION = "0.8.1.liveramp-002".freeze
   end
 end


### PR DESCRIPTION
The id of the service account key used to sign JWTs to request IAP
access tokens is also encoded in the JWT headers. This is not the
prettiest way to standardize reading this value from the keyfile json,
but it's better than reading it outside of the ServiceCredentials class.
The whole structure of the key / signer handling in this gem probably
wants a reevaluation if the intent will be to continue using it for IAP
tokens. The google-auth-library-python package could serve as a good
guide for making the JWT handling a little cleaner. In particular, it'd
be great to get rid of the 4-element array response from the
read_json_io module method.

A change in Signet allows custom jwt headers, which will be necessaary
for downstream users of this gem. This updates to that (liveramp-forked)
version of Signet and also updates the liveramp fork version of this
gem.